### PR TITLE
testing: use the new WindmillDirAt function so that we don't need to stub env variables

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -40,11 +40,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:65a64b11285bf3d99945a76fd15e6841724ece37f927a92f117caa6a40502688"
+  digest = "1:95fe9a3d458a0e40c0cc4cdcecf21cc084c88713c269fb60b24b1d09fc81239c"
   name = "github.com/windmilleng/wmclient"
   packages = ["pkg/dirs"]
   pruneopts = "UT"
-  revision = "45c5f1c151536951c55106d1958cca500385ed1d"
+  revision = "31c1725257e1cbda5a40d73bdbb0e824bda27ff6"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/internal/proc/procfs.go
+++ b/internal/proc/procfs.go
@@ -24,12 +24,15 @@ func NewProcFS() (ProcFS, error) {
 	if err != nil {
 		return ProcFS{}, fmt.Errorf("NewProcFS: %v", err)
 	}
+	return NewProcFSWithDir(wmDir)
+}
 
+func NewProcFSWithDir(wmDir *dirs.WindmillDir) (ProcFS, error) {
 	fs := ProcFS{
 		wmDir: wmDir,
 		mu:    &sync.Mutex{},
 	}
-	err = fs.RemoveDeadProcs()
+	err := fs.RemoveDeadProcs()
 	if err != nil {
 		return ProcFS{}, fmt.Errorf("NewProcFS: %v", err)
 	}

--- a/internal/proc/procfs_test.go
+++ b/internal/proc/procfs_test.go
@@ -37,13 +37,9 @@ func TestProcFSHost(t *testing.T) {
 	f := newProcFixture(t)
 	defer f.tearDown()
 
-	procfs, err := NewProcFS()
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	procfs := f.newProcFS()
 	proc := PetsProc{Pid: 12345}
-	err = procfs.AddProc(proc)
+	err := procfs.AddProc(proc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,29 +84,25 @@ func TestProcFSRemoveDead(t *testing.T) {
 }
 
 type procFixture struct {
-	t       *testing.T
-	oldHome string
-	dir     string
+	t   *testing.T
+	dir string
 }
 
 func newProcFixture(t *testing.T) *procFixture {
 	dir, _ := ioutil.TempDir("", t.Name())
-	oldHome := os.Getenv("HOME")
-	os.Setenv("HOME", dir)
 	return &procFixture{
-		t:       t,
-		oldHome: oldHome,
-		dir:     dir,
+		t:   t,
+		dir: dir,
 	}
 }
 
 func (f *procFixture) tearDown() {
 	os.RemoveAll(f.dir)
-	os.Setenv("HOME", f.oldHome)
 }
 
 func (f *procFixture) newProcFS() ProcFS {
-	procfs, err := NewProcFS()
+	wmDir := dirs.NewWindmillDirAt(f.dir)
+	procfs, err := NewProcFSWithDir(wmDir)
 	if err != nil {
 		f.t.Fatal(err)
 	}
@@ -118,8 +110,7 @@ func (f *procFixture) newProcFS() ProcFS {
 }
 
 func (f *procFixture) procFile() string {
-	wmdir, _ := dirs.GetWindmillDir()
-	return filepath.Join(wmdir, procPath)
+	return filepath.Join(f.dir, procPath)
 }
 
 func (f *procFixture) assertProcFile(expected string) {

--- a/vendor/github.com/windmilleng/wmclient/pkg/dirs/dirs.go
+++ b/vendor/github.com/windmilleng/wmclient/pkg/dirs/dirs.go
@@ -64,6 +64,11 @@ func UseWindmillDir() (*WindmillDir, error) {
 	return &WindmillDir{dir: dir}, nil
 }
 
+// Create a windmill dir at an arbitrary directory. Useful for testing.
+func NewWindmillDirAt(dir string) *WindmillDir {
+	return &WindmillDir{dir: dir}
+}
+
 type WindmillDir struct {
 	dir string
 }


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/tests:

3aa09bc3f83d5f4619bd6067a291867cebf08268 (2018-07-26 15:27:40 -0400)
testing: use the new WindmillDirAt function so that we don't need to stub env variables