### PR TITLE
health: print the logs of the failing process when health check fails

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -52,8 +52,6 @@ func WaitForTCP(process proc.PetsProc, interval time.Duration) error {
 				continue
 			}
 
-			// TODO(nick): We need to propagate this in a way so that the user
-			// gets access to the stdout/stderr of the failed process
 			return fmt.Errorf("Process died without opening a network connection")
 		}
 

--- a/internal/mill/exec.go
+++ b/internal/mill/exec.go
@@ -396,7 +396,13 @@ func (p *Petsitter) waitOnHealthCheck(t *skylark.Thread, pr proc.PetsProc) error
 	<-waitingCh
 
 	if err != nil {
-		return fmt.Errorf("Health check (%s, %s) failed: %v", key, pr.Host(), err)
+		logs := ""
+		contents, readErr := p.Procfs.ReadLogFile(key)
+		if readErr == nil && contents != "" {
+			logs = fmt.Sprintf("\n%s logs:\n%s", key, contents)
+		}
+
+		return fmt.Errorf("Health check (%s, %s) failed: %v%s", key, pr.Host(), err, logs)
 	}
 
 	return nil

--- a/internal/mill/exec_test.go
+++ b/internal/mill/exec_test.go
@@ -393,7 +393,10 @@ register("blorg-frontend", "local", start_local)
 	school := f.petsitter.School
 	key := service.NewKey("blorg-frontend", "local")
 	_, err = school.UpByKey(key)
-	if err == nil || !strings.Contains(err.Error(), "Process died without opening a network connection") {
+	if err == nil ||
+		!strings.Contains(err.Error(), "Process died without opening a network connection") ||
+		!strings.Contains(err.Error(), "blorg-frontend-local logs") ||
+		!strings.Contains(err.Error(), "meow") {
 		t.Errorf("Expected health check error. Actual: %v", err)
 	}
 }


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/error:

5adf59d65c5bf58e6102a7f62f8d800126a11459 (2018-08-09 20:17:58 -0400)
health: print the logs of the failing process when health check fails